### PR TITLE
Revert disabling Pam's HC integration by default

### DIFF
--- a/src/main/java/tonius/neiintegration/mods/harvestcraft/HarvestCraftIntegration.java
+++ b/src/main/java/tonius/neiintegration/mods/harvestcraft/HarvestCraftIntegration.java
@@ -13,11 +13,6 @@ public class HarvestCraftIntegration extends IntegrationBase {
     }
 
     @Override
-    public boolean isEnabledByDefault() {
-        return false;
-    }
-
-    @Override
     public boolean isValid() {
         return Utils.isModLoaded("harvestcraft");
     }


### PR DESCRIPTION
Don't disable Pam's HC integration in the config by default (reverts #7), this will be achieved by adding the config in the modpack instead (done [here](https://github.com/GTNewHorizons/GT-New-Horizons-Modpack/pull/13964))